### PR TITLE
env variable `BROKER_POOL_LIMIT` from `int` to `string`

### DIFF
--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -35,7 +35,7 @@ except KeyError:
     broker = DEFAULT_RABBITMQ_BROKER
     os.environ.setdefault("CELERY_BROKER_URL", DEFAULT_RABBITMQ_BROKER)
 
-os.environ.setdefault("BROKER_POOL_LIMIT", 1)
+os.environ.setdefault("BROKER_POOL_LIMIT", "1")
 
 celery_app = Celery(
     "tasks", broker=os.environ.get("CELERY_BROKER_URL", DEFAULT_RABBITMQ_BROKER)


### PR DESCRIPTION
```
File "BioMLHackathon_ResurrectionSquad\backend\app\tasks.py", line 38, in <module>
    os.environ.setdefault("BROKER_POOL_LIMIT", 1)
File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.10_3.10.3056.0_x64__qbz5n2kfra8p0\lib\os.py", line 717, in setdefault
    self[key] = value
File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.10_3.10.3056.0_x64__qbz5n2kfra8p0\lib\os.py", line 685, in __setitem__
    value = self.encodevalue(value)
File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.10_3.10.3056.0_x64__qbz5n2kfra8p0\lib\os.py", line 743, in check_str
    raise TypeError("str expected, not %s" % type(value).__name__)
TypeError: str expected, not int
```